### PR TITLE
Undefined variable $obje  bug fix

### DIFF
--- a/src/Record/Fam/Even.php
+++ b/src/Record/Fam/Even.php
@@ -105,7 +105,7 @@ class Even extends \Gedcom\Record implements Objectable, Sourceable, Noteable
      */
     public function getObje()
     {
-        return $this->obje;
+        return $this->_obje;
     }
 
     /**


### PR DESCRIPTION
Gedcom import throws an error because of undefined variable $obje. Fixed typo mistake.